### PR TITLE
Add missing dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "j2v8-react-demo",
   "devDependencies": {
+    "babel-cli": "^6.11.4",
     "babel-preset-es2015": "^6.9.0",
     "babel-preset-react": "^6.11.1",
     "babelify": "^7.3.0",


### PR DESCRIPTION
Add babel-cli module for benchmarks depend on JavaScript
